### PR TITLE
Allow for renaming repo when forking

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build Static Web App
         run: npm run build -- --base=$BASE_URL
         env:
-          BASE_URL: anyonecancode
+          BASE_URL: ${{ github.event.repository.name }}
           VITE_FACE_API_KEY: ${{ secrets.VITE_FACE_API_KEY }}
           VITE_SPEECH_API_KEY: ${{ secrets.VITE_SPEECH_API_KEY }}
           VITE_IMAGE_API_URL: ${{secrets.VITE_IMAGE_API_URL}}


### PR DESCRIPTION
Hardcoding the base-url to the repo name breaks challenge 2 if the user renames the repo when forking. If we use the github context to provide reponame at build time it will work better.