### PR TITLE
Update README.md

### DIFF
--- a/instructions/day1/Application/README.md
+++ b/instructions/day1/Application/README.md
@@ -254,7 +254,7 @@ Now that we are sure that our backend service works as expected, we can bring ev
 To do this, we will use a GitHub feature called _Secrets_, where you can store your backend URL to make your frontend talk to the backend service.
 
 - On your Repository page in GitHub select _Settings_ and navigate to _Secrets_ > _Actions_.
-- Add a _New repository secret_ named `VITE_APP_IMAGE_API_URL` and as value set `<your WebApp's URL>`.
+- Add a _New repository secret_ named `VITE_IMAGE_API_URL` and as value set `<your WebApp's URL>`.
   > ⚠️⚠️ Your URL should end on a **/**. It should look like this: `https://xxxx.azurewebsites.net/`
   ![GitHub frontend URL](./images/light/FrontendAPIUrl.png) > ![GitHub Secrets Create](./images/light/CreateSecret.png)
 


### PR DESCRIPTION
settings.ts as the follow definitions:
const imageApiUrl = import.meta.env.VITE_IMAGE_API_URL || ""; const faceApiKey = import.meta.env.VITE_FACE_API_KEY || ""; const speechApiKey = import.meta.env.VITE_SPEECH_API_KEY || ""; const faceApiEndpoint = import.meta.env.VITE_FACE_API_ENDPOINT || ""; const visionApiKey = import.meta.env.VITE_VISION_API_KEY || ""; const visionApiEndpoint = import.meta.env.VITE_VISION_API_ENDPOINT || "";


In section Integrate Azure Wev App URL in GitHub Secrets, it states:

Add a New repository secret named VITE_APP_IMAGE_API_URL and as value set <your WebApp's URL> It should be VITE_IMAGE_API_URL not VITE_APP_IMAGE_API_URL.